### PR TITLE
bugfix: Add message variable declaration in outer scope

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,13 +58,15 @@ def job():
                 soup = bs(mentolec_page.text, 'html.parser')
                 new_lec = soup.select_one('#listFrm > table > tbody > tr:nth-child(1) > td.tit > div.rel > a').attrs['href']
                 new_lec_name = soup.select_one('#listFrm > table > tbody > tr:nth-child(1) > td.tit > div.rel > a').get_text().strip()
+                message = {}
                 if not recent_lec:
                     message = {'content': '알림봇 시작!'}
                 elif new_lec != recent_lec:
                     message = {'content': ''.join(['NEW 소마 강의 : ', 
                                                 new_lec_name,
                                                 '\n바로가기 : https://www.swmaestro.org', new_lec]) }
-                requests.post(DISCORD_WEBHOOK_URL, data=message, verify=False)
+                if 'content' in message:
+                    requests.post(DISCORD_WEBHOOK_URL, data=message, verify=False)
                 recent_lec = new_lec
 
 job()


### PR DESCRIPTION
분기문 내 변수 선언 후 상위 스코프에서 해당 변수에 접근하여 아래와 같은 오류가 발생하였습니다.
```bash
UnboundLocalError: local variable 'message' referenced before assignment
```

다음과 같이 수정하였습니다.

```Python3
# Declare message variable
message = {}
if not recent_lec:
    # ... Assign value to message
elif new_lec != recent_lec:
    # ... Assign value to message
if 'content' in message:
    requests.post(DISCORD_WEBHOOK_URL, data=message, verify=False)
```